### PR TITLE
N-param op code reuse

### DIFF
--- a/easier68k/core/opcodes/move.py
+++ b/easier68k/core/opcodes/move.py
@@ -19,16 +19,17 @@ class Move(Opcode):
     # Allowed sizes for this opcode
     valid_sizes = [OpSize.BYTE, OpSize.WORD, OpSize.LONG]
 
-    def __init__(self, src: AssemblyParameter, dest: AssemblyParameter, size: OpSize = OpSize.WORD):
-        assert isinstance(src, AssemblyParameter)
-        assert isinstance(dest, AssemblyParameter)
+    def __init__(self, params: list, size: OpSize = OpSize.WORD):
+        assert len(params) == 2
+        assert isinstance(params[0], AssemblyParameter)
+        assert isinstance(params[1], AssemblyParameter)
         # Check that the src is of the proper type (for example, can't move from an address register for a move command)
-        assert src.mode != EAMode.ARD  # Only invalid src is address register direct
-        self.src = src
+        assert params[0].mode != EAMode.ARD  # Only invalid src is address register direct
+        self.src = params[0]
 
         # Check that the destination is of a proper type
-        assert dest.mode != EAMode.ARD and dest.mode != EAMode.IMM  # Can't take address register direct or immediates
-        self.dest = dest
+        assert params[1].mode != EAMode.ARD and params[1].mode != EAMode.IMM  # Can't take address register direct or immediates
+        self.dest = params[1]
 
         # Check that this is a valid size (for example, 'MOVEA.B' is not a valid command)
 
@@ -178,8 +179,8 @@ class Move(Opcode):
         :param parameters: The parameters after the command (such as the source and destination of a move)
         :return: Whether the given command is valid and a list of issues/warnings encountered
         """
-        return opcode_util.two_param_is_valid(command, parameters, "MOVE", param1_invalid_modes=[EAMode.ARD],
-                                              param2_invalid_modes=[EAMode.ARD, EAMode.IMM])
+        return opcode_util.n_param_is_valid(command, parameters, "MOVE", 2, param_invalid_modes=[[EAMode.ARD],
+                                              [EAMode.ARD, EAMode.IMM]])
 
     @classmethod
     def from_binary(cls, data: bytearray) -> (Move, int):
@@ -281,7 +282,7 @@ class Move(Opcode):
 
         # when making the new Move, need to convert that MoveSize back into an OpSize
 
-        return cls(src_EA[0], dest_EA[0], size), wordsUsed
+        return cls([src_EA[0], dest_EA[0]], size), wordsUsed
 
     @classmethod
     def from_str(cls, command: str, parameters: str):
@@ -298,4 +299,4 @@ class Move(Opcode):
         :param parameters: The parameters after the command (such as the source and destination of a move)
         :return: The parsed command
         """
-        return opcode_util.two_param_from_str(command, parameters, Move, OpSize.WORD)
+        return opcode_util.n_param_from_str(command, parameters, Move, 2, OpSize.WORD)

--- a/easier68k/core/opcodes/simhalt.py
+++ b/easier68k/core/opcodes/simhalt.py
@@ -114,9 +114,4 @@ class Simhalt(Opcode):
         :param command: The command itself (e.g. 'MOVE.B', 'LEA', etc.)
         :param parameters: The parameters after the command (such as the source and destination of a move)
         """
-        valid, issues = Simhalt.is_valid(command, parameters)
-        if not valid:
-            return None
-        # We can forego asserts in here because we've now confirmed this is valid assembly code
-
         return cls()

--- a/easier68k/core/util/opcode_util.py
+++ b/easier68k/core/util/opcode_util.py
@@ -1,6 +1,7 @@
 from ..enum.ea_mode import EAMode
-from ..util.parsing import parse_assembly_parameter
+from ..util.parsing import parse_assembly_parameter, from_str_util
 from ..enum.op_size import OpSize
+
 
 def command_matches(command: str, template: str) -> bool:
     """
@@ -150,3 +151,77 @@ def ea_to_binary_post_op(ea: EAMode, size: OpSize) -> str:
         return '{0:032b}'.format(ea.data)
 
     return ''  # This EA doesn't have a necessary post-op
+
+
+def two_param_is_valid(command: str, parameters: str, opcode: str, valid_sizes=[OpSize.LONG, OpSize.WORD, OpSize.BYTE],
+                       default_size=OpSize.WORD, param1_invalid_modes=[], param2_invalid_modes=[]) -> (bool, list):
+    """
+    Tests whether the given command is valid
+
+    :param command: The command itself (e.g. 'MOVE.B', 'LEA', etc.)
+    :param parameters: The parameters after the command (such as the source and destination of a move)
+    :param opcode: The opcode to check for ('MOVE', 'LEA', etc.)
+    :param valid_sizes: valid sizes of the command (empty list or None for no size)
+    :param default_size: the default size for the command (can be None if it doesn't take a command)
+    :param param1_invalid_modes: invalid modes for the first parameter
+    :param param2_invalid_modes: invalid modes for the second parameter
+    :return: Whether the given command is valid and a list of issues/warnings encountered
+    """
+    issues = []
+    try:
+        size, params, parts = from_str_util(command, parameters)
+
+        # If we have more than 2 parts something is seriously wrong
+        assert len(parts) <= 2, 'Unknown error (more than 1 period in command)'
+        assert parts[0].upper() == opcode.upper(), "Command doesn't match template {}".format(opcode)
+        # Size check
+        if valid_sizes is not None and len(valid_sizes) > 0:
+            if not size:
+                # If size is null but we had a size parameter, it was an invalid size
+                assert len(parts) == 1, 'Invalid size parameter'
+                size = default_size
+            assert size in valid_sizes, 'Size {} is not a valid size'.format(size)
+        else:
+            assert len(parts) == 1, "Can't specify a size for command {}".format(opcode)
+
+        assert len(params) == 2, 'Opcode {} must have two parameters'.format(opcode)
+
+        param1 = parse_assembly_parameter(params[0])
+        param2 = parse_assembly_parameter(params[1])
+
+        assert param1.mode not in param1_invalid_modes, 'Invalid addressing mode'
+        assert param2.mode not in param2_invalid_modes, 'Invalid addressing mode'
+
+    except AssertionError as e:
+        issues.append((e.args[0], 'ERROR'))
+        return False, issues
+
+    return True, issues
+
+
+def two_param_from_str(command: str, parameters: str, opcode_cls, default_size=OpSize.WORD):
+    """
+    Parses a command from text. Note that this assumes that is_valid has already been run and was successful.
+
+    :param command: The command itself (e.g. 'MOVE.B', 'LEA', etc.)
+    :param parameters: The parameters after the command (such as the source and destination of a move)
+    :param opcode_cls: The class of opcode we're parsing to
+    :param opcode: The opcode template (like 'MOVE', 'LEA', etc.)
+    :param default_size: The default size if no size is specified, or None if this is an unsized opcode
+    :return: The parsed command
+    """
+    size, params, parts = from_str_util(command, parameters)
+
+    if default_size and not size:
+        size = default_size
+    elif not default_size:
+        size = None
+
+    param1 = parse_assembly_parameter(params[0].strip())
+    param2 = parse_assembly_parameter(params[1].strip())
+
+    if size:
+        return opcode_cls(param1, param2, size)
+    else:
+        return opcode_cls(param1, param2)
+

--- a/easier68k/core/util/opcode_util.py
+++ b/easier68k/core/util/opcode_util.py
@@ -63,7 +63,8 @@ def get_size(command: str, default_size=OpSize.WORD) -> OpSize:
     return OpSize.parse(split[1])
 
 
-def check_valid_command(command: str, template: str, can_take_size=True, valid_sizes=[OpSize.LONG, OpSize.WORD, OpSize.BYTE]) -> bool:
+def check_valid_command(command: str, template: str, can_take_size=True,
+                        valid_sizes=[OpSize.LONG, OpSize.WORD, OpSize.BYTE]) -> bool:
     """
     Checks whether this command is valid
 
@@ -224,4 +225,3 @@ def two_param_from_str(command: str, parameters: str, opcode_cls, default_size=O
         return opcode_cls(param1, param2, size)
     else:
         return opcode_cls(param1, param2)
-

--- a/tests/easier68k/core/opcodes/test_lea.py
+++ b/tests/easier68k/core/opcodes/test_lea.py
@@ -24,7 +24,7 @@ def test_lea():
     dst = AssemblyParameter(EAMode.ARD, 3)
 
     # make a testing move command
-    lea = Lea(src, dst)
+    lea = Lea([src, dst])
 
     lea.execute(a)
 

--- a/tests/easier68k/core/opcodes/test_move.py
+++ b/tests/easier68k/core/opcodes/test_move.py
@@ -25,7 +25,7 @@ def test_move():
     dst = AssemblyParameter(EAMode.DRD, 2)
 
     # make a testing move command
-    mv = Move(src, dst, OpSize.BYTE)
+    mv = Move([src, dst], OpSize.BYTE)
 
     mv.execute(a)
 


### PR DESCRIPTION
Attempting to take out functionality from Move and split it into some reusable methods to ease the creation of some N-parameter opcodes.