### PR TITLE
Add NEG

### DIFF
--- a/easier68k/core/opcodes/__init__.py
+++ b/easier68k/core/opcodes/__init__.py
@@ -9,5 +9,6 @@ __all__ = [
     'add',
     'sub',
     'subq',
-    'adda'
+    'adda',
+    'neg'
 ]

--- a/easier68k/core/opcodes/neg.py
+++ b/easier68k/core/opcodes/neg.py
@@ -12,11 +12,31 @@ from ..enum.condition_status_code import ConditionStatusCode
 from ..models.memory_value import MemoryValue
 
 
-class Neg(Opcode):  # Forward declaration
-    pass
-
-
 class Neg(Opcode):
+    """
+    NEG: Negate
+    Operation: 0 - Destination -> Destination
+    Assembler Syntax: NEG <ea>
+    Attributes: Size = (Byte, Word, Long)
+    Description: Subtracts the destination operand from zero
+                 and stores the result in the destination location.
+                 The size of the operation is specified as byte, word, or long.
+    Condition Codes: X - Set the same as the carry bit.
+                     N - Set if the result is negative; cleared otherwise.
+                     Z - Set if the result is zero; cleared otherwise.
+                     V - Set if an overflow occurs; cleared otherwise.
+                     C - Cleared if the result is zero; set otherwise.
+    Instruction Format: 01000100 Signature xx Size xxx EAMode xxx EARegister
+    Instruction Fields:
+        Size field - Specifies the size of the operation.
+            00 - Byte operation.
+            01 - Word operation.
+            10 - Long operation.
+        Effective Address field - Specifies the address of the next instruction.
+                                  Only data alterable addressing modes can be used.
+            Valid Modes - Dn, (An), (An)+, -(An), (xxx).W, (xxx).L
+    """
+
     # Allowed sizes for this opcode
     valid_sizes = [OpSize.BYTE, OpSize.WORD, OpSize.LONG]
 

--- a/easier68k/core/opcodes/neg.py
+++ b/easier68k/core/opcodes/neg.py
@@ -110,13 +110,18 @@ class Neg(Opcode):
         negative = total & negative_bit > 0
 
         # Overflow occurs when a sign change occurs where it shouldn't occur.
-        # For example: positive - negative != negative.
+        # For example:   0 - positive != positive.
+        # other example: 0 - negative != negative
         # This doesn't make sense, so an overflow occurs
         overflow = False
 
-        if dest_val.get_value_unsigned() & 0x80000000 > 0:
-            if total & negative_bit == 0:
-                overflow = True
+        if total != 0:
+            if dest_val.get_value_unsigned() & negative_bit == 0:  # If it is positive
+                if total & negative_bit == 0:  # And total is positive
+                    overflow = True
+            elif dest_val.get_value_unsigned() & negative_bit > 0:  # If it is negative
+                if total & negative_bit > 0:  # If the total is negative
+                    overflow = True
 
         # Cleared if the result is 0.
         carry_bit = total != 0

--- a/easier68k/core/opcodes/neg.py
+++ b/easier68k/core/opcodes/neg.py
@@ -1,0 +1,309 @@
+from ...core.enum.ea_mode import EAMode
+from ...core.enum.op_size import OpSize
+from ...core.enum import ea_mode_bin
+from ...core.enum.ea_mode_bin import parse_ea_from_binary
+from ...simulator.m68k import M68K
+from ...core.opcodes.opcode import Opcode
+from ...core.util.split_bits import split_bits
+from ...core.util import opcode_util
+from ..util.parsing import parse_assembly_parameter
+from ..models.assembly_parameter import AssemblyParameter
+from ..enum.condition_status_code import ConditionStatusCode
+from ..models.memory_value import MemoryValue
+
+
+class Neg(Opcode):  # Forward declaration
+    pass
+
+
+class Neg(Opcode):
+    # Allowed sizes for this opcode
+    valid_sizes = [OpSize.BYTE, OpSize.WORD, OpSize.LONG]
+
+    def __init__(self, params: list, size: OpSize = OpSize.WORD):
+        assert len(params) == 1
+        assert isinstance(params[0], AssemblyParameter)
+
+        # check ea param is valid
+        assert params[0].mode != EAMode.ARD or params[0].mode != EAMode.IMM
+        self.dest = params[0]
+
+        assert size in Neg.valid_sizes
+        self.size = size
+
+    def assemble(self) -> bytearray:
+        """
+        Assembles this opcode into hex to be inserted into memory
+        :return: The hex version of this opcode
+        """
+
+        # 1101 Dn xxx D x S xx M xxx Xn xxx
+        # ret_opcode is the binary value which represents the assembled instruction
+        ret_opcode = 0b01000100 << 8
+
+        if self.size == OpSize.BYTE:
+            ret_opcode |= 0b00 << 6
+        elif self.size == OpSize.WORD:
+            ret_opcode |= 0b01 << 6
+        elif self.size == OpSize.LONG:
+            ret_opcode |= 0b10 << 6
+
+        ret_opcode |= ea_mode_bin.parse_from_ea_mode_modefirst(self.dest) << 0
+
+        ret_bytes = bytearray(ret_opcode.to_bytes(2, byteorder='big', signed=False))
+
+        if self.dest.mode == EAMode.AWA or self.dest.mode == EAMode.ALA:
+            ret_bytes.extend(opcode_util.ea_to_binary_post_op(self.dest, self.size).get_value_bytearray())
+
+        return ret_bytes
+
+    def execute(self, simulator: M68K):
+        """
+        Executes this command in a simulator
+        :param simulator: The simulator to execute the command on
+        :return: Nothing
+        """
+        # get the length
+        val_length = self.size.get_number_of_bytes()
+
+        # get the value of src from the simulator
+        dest_val = self.dest.get_value(simulator, val_length)
+
+        # increment the program counter by the length of the instruction (1 word)
+        to_increment = OpSize.WORD.value
+
+        # repeat for the dest
+        if self.dest.mode in [EAMode.AbsoluteLongAddress]:
+            to_increment += OpSize.LONG.value
+
+        if self.dest.mode in [EAMode.AbsoluteWordAddress]:
+            to_increment += OpSize.WORD.value
+
+        # mask to apply to the source
+        mask = 0xFF
+
+        if self.size is OpSize.BYTE:
+            mask = 0xFF
+        if self.size is OpSize.WORD:
+            mask = 0xFFFF
+        if self.size is OpSize.LONG:
+            mask = 0xFFFFFFFF
+
+        # which bits of the total should not be modified
+        inverted_mask = 0xFFFFFFFF ^ mask
+
+        # preserve the upper bits of the operation if they aren't used
+        preserve = dest_val.get_value_signed() & inverted_mask
+        raw_total = 0 - dest_val.get_value_unsigned()
+
+        total = (raw_total & mask) | preserve
+
+        negative_bit = 0
+
+        if self.size is OpSize.BYTE:
+            negative_bit = 0x80
+        elif self.size is OpSize.WORD:
+            negative_bit = 0x8000
+        elif self.size is OpSize.LONG:
+            negative_bit = 0x80000000
+
+        negative = total & negative_bit > 0
+
+        # Overflow occurs when a sign change occurs where it shouldn't occur.
+        # For example: positive - negative != negative.
+        # This doesn't make sense, so an overflow occurs
+        overflow = False
+
+        if dest_val.get_value_unsigned() & 0x80000000 > 0:
+            if total & negative_bit == 0:
+                overflow = True
+
+        # Cleared if the result is 0.
+        carry_bit = total != 0
+
+        # set the same as the 'C' bit
+        simulator.set_condition_status_code(ConditionStatusCode.X, carry_bit)
+        # set if result is negative
+        simulator.set_condition_status_code(ConditionStatusCode.N, negative)
+        # set if result is zero
+        simulator.set_condition_status_code(ConditionStatusCode.Z, total == 0)
+        # set if an overflow is generated, cleared otherwise
+        simulator.set_condition_status_code(ConditionStatusCode.V, overflow)
+        # set if a borrow is generated, cleared otherwise
+        simulator.set_condition_status_code(ConditionStatusCode.C, carry_bit)
+
+        # and set the value
+        self.dest.set_value(simulator, MemoryValue(OpSize.LONG, unsigned_int=total))
+
+        # set the program counter value
+        simulator.increment_program_counter(to_increment)
+
+    def __str__(self):
+        # Makes this a bit easier to read in doctest output
+        return 'Neg command: Size {}, dest {}'.format(self.size, self.dest)
+
+    @classmethod
+    def command_matches(cls, command: str) -> bool:
+        """
+        Checks whether a command string is an instance of this command type
+        :param command: The command string to check (e.g. 'MOVE.B', 'LEA', etc.)
+        :return: Whether the string is an instance of this command type
+        """
+        return opcode_util.command_matches(command, 'SUB')
+
+    @classmethod
+    def get_word_length(cls, command: str, parameters: str) -> int:
+        """
+        >>> Neg.get_word_length('NEG.B', 'D3')
+        1
+
+        >>> Neg.get_word_length('NEG.W', '-(A5)')
+        1
+
+        >>> Neg.get_word_length('NEG.B', '($BBBB).W')
+        2
+
+        >>> Neg.get_word_length('NEG.W', '(A0)+')
+        1
+
+        >>> Neg.get_word_length('NEG.W', '($BBBB).W')
+        2
+
+        >>> Neg.get_word_length('NEG.L', '($BBBB).L')
+        3
+
+        Gets what the end length of this command will be in memory
+        :param command: The text of the command itself (e.g. "LEA", "MOVE.B", etc.)
+        :param parameters: The parameters after the command
+        :return: The length of the bytes in memory in words, as well as a list of warnings or errors encountered
+        """
+
+        # Split the parameters into EA modes
+        params = parameters.split(',')
+
+        # src = parse_assembly_parameter(params[0].strip())  # Parse the source and make sure it parsed right
+        dest = parse_assembly_parameter(params[0].strip())
+
+        length = 1  # Always 1 word not counting additions to end
+
+        if dest.mode == EAMode.AWA:  # Appends a word
+            length += 1
+
+        if dest.mode == EAMode.ALA:  # Appends a long, so 2 words
+            length += 2
+
+        return length
+
+    @classmethod
+    def is_valid(cls, command: str, parameters: str) -> (bool, list):
+        """
+        Tests whether the given command is valid
+
+        >>> Neg.is_valid('NEG.B', 'D1')[0]
+        True
+
+        >>> Neg.is_valid('NEG.W', '(A5)')[0]
+        True
+
+        >>> Neg.is_valid('NEG.B', '#5, D1')[0]
+        False
+
+        >>> Neg.is_valid('NEG.L', 'D2')[0]
+        True
+
+        >>> Neg.is_valid('NE.L', 'D1')[0]
+        False
+
+        >>> Neg.is_valid('NEG.', 'D1')[0]
+        False
+
+        >>> Neg.is_valid('NEG.W', '($7000).W')[0]
+        True
+
+        :param command: The command itself (e.g. 'MOVE.B', 'LEA', etc.)
+        :param parameters: The parameters after the command (such as the source and destination of a move)
+        :return: Whether the given command is valid and a list of issues/warnings encountered
+        """
+        return opcode_util.n_param_is_valid(command, parameters, "NEG", 1, param_invalid_modes=[[EAMode.ARD,
+                                                                                                 EAMode.IMM]])[:2]
+
+    @classmethod
+    def disassemble_instruction(cls, data: bytearray) -> Opcode:
+        """
+        This has a non-subq opcode
+        >>> Neg.disassemble_instruction(bytearray.fromhex('0280'))
+
+
+        NEG.B D7
+        >>> op = Neg.disassemble_instruction(bytearray.fromhex('4407'))
+
+        >>> str(op.dest)
+        'EA Mode: EAMode.DRD, Data: 7'
+
+
+        NEG.W (A5)
+        >>> op = Neg.disassemble_instruction(bytearray.fromhex('4455'))
+
+        >>> str(op.dest)
+        'EA Mode: EAMode.ARI, Data: 5'
+
+        NEG.L (A0)+
+        >>> op = Neg.disassemble_instruction(bytearray.fromhex('4498'))
+
+        >>> str(op.dest)
+        'EA Mode: EAMode.ARIPI, Data: 0'
+
+        NEG.W $4000
+        >>> op = Neg.disassemble_instruction(bytearray.fromhex('44784000'))
+
+        >>> str(op.dest)
+        'EA Mode: EAMode.AWA, Data: 16384'
+
+        Parses some raw data into an instance of the opcode class
+        :param data: The data used to convert into an opcode instance
+        :return: The constructed instance or none if there was an error and
+            the amount of data in words that was used (e.g. extra for immediate
+            data) or 0 for not a match
+        """
+        assert len(data) >= 2, 'Opcode size is at least one word'
+
+        first_word = int.from_bytes(data[0:2], 'big')
+        [opcode_bin,
+         size_bin,
+         ea_mode_binary,
+         ea_reg_bin] = split_bits(first_word, [8, 2, 3, 3])
+
+        if opcode_bin != 0b01000100:
+            return None
+
+        # Determine size
+        if size_bin == 0b00:
+            size = OpSize.BYTE
+        elif size_bin == 0b01:
+            size = OpSize.WORD
+        elif size_bin == 0b10:
+            size = OpSize.LONG
+        else:
+            return None
+
+        # populate destination data
+        dest = parse_ea_from_binary(ea_mode_binary, ea_reg_bin, size, False, data[2:])[0]
+
+        return cls([dest], size)
+
+    @classmethod
+    def from_str(cls, command: str, parameters: str):
+        """
+        Parses a NEG command from text.
+
+        >>> str(Neg.from_str('NEG.B', 'D1'))
+        'Neg command: Size OpSize.BYTE, dest EA Mode: EAMode.DRD, Data: 1'
+
+        >>> str(Neg.from_str('NEG.L', '(A0)'))
+        'Neg command: Size OpSize.LONG, dest EA Mode: EAMode.ARI, Data: 0'
+
+        :param command: The command itself (e.g. 'MOVE.B', 'LEA', etc.)
+        :param parameters: The parameters after the command (such as the source and destination of a move)
+        :return: The parsed command
+        """
+        return opcode_util.n_param_from_str(command, parameters, Neg, 1, OpSize.WORD)

--- a/easier68k/core/opcodes/neg.py
+++ b/easier68k/core/opcodes/neg.py
@@ -37,7 +37,7 @@ class Neg(Opcode):
         :return: The hex version of this opcode
         """
 
-        # 1101 Dn xxx D x S xx M xxx Xn xxx
+        # 01000100 Signature xx Size xxx EAMode xxx EARegister
         # ret_opcode is the binary value which represents the assembled instruction
         ret_opcode = 0b01000100 << 8
 

--- a/tests/easier68k/core/opcodes/__init__.py
+++ b/tests/easier68k/core/opcodes/__init__.py
@@ -8,5 +8,6 @@ __all__ = [
     'test_or',
     'test_ori',
     'test_eor',
-    'test_adda'
+    'test_adda',
+    'test_neg'
 ]

--- a/tests/easier68k/core/opcodes/test_neg.py
+++ b/tests/easier68k/core/opcodes/test_neg.py
@@ -1,0 +1,152 @@
+"""
+Test method for NEG opcode
+
+"""
+
+from easier68k.simulator.m68k import M68K
+from easier68k.core.opcodes.neg import Neg
+from easier68k.core.models.assembly_parameter import AssemblyParameter
+from easier68k.core.enum.ea_mode import EAMode
+from easier68k.core.enum.register import Register
+from easier68k.core.enum.op_size import OpSize
+from easier68k.core.models.memory_value import MemoryValue
+from .test_opcode_helper import run_opcode_test
+
+
+def test_neg():
+    """
+    Test to see that it can negate a positive number.
+
+    Example case used:
+        MOVE.W #123,D0
+        NEG.W D0
+    """
+
+    sim = M68K()
+
+    sim.set_program_counter_value(0x1000)
+
+    sim.set_register(Register.D0, MemoryValue(OpSize.WORD, unsigned_int=123))
+
+    neg = Neg([AssemblyParameter(EAMode.DRD, 0)], OpSize.WORD)  # NEG.W D0
+
+    run_opcode_test(sim, neg, Register.D0, 0xFF85, 2, [True, True, False, False, True])
+
+
+def test_neg_negative():
+    """
+    Test to see that neg can handle negative values.
+
+    Example case used:
+        MOVE.L #-2,D2
+        NEG.L D2
+    """
+
+    sim = M68K()
+
+    sim.set_program_counter_value(0x1000)
+
+    sim.set_register(Register.D2, MemoryValue(OpSize.LONG, signed_int=-2))
+
+    neg = Neg([AssemblyParameter(EAMode.DRD, 2)], OpSize.LONG)  # NEG.L D2
+
+    run_opcode_test(sim, neg, Register.D2, 0x2, 2, [True, False, False, False, True])
+
+
+def test_neg_disassembles():
+    """
+    Test to see that neg can be assembled from some input
+
+    Example case used:
+        MOVE.W #$123,D0
+        NEG.B D0
+    """
+
+    data = bytearray.fromhex('4400')
+
+    result = Neg.disassemble_instruction(data)
+
+    assert result is not None
+
+    sim = M68K()
+
+    sim.set_register(Register.D0, MemoryValue(OpSize.WORD, unsigned_int=0x123))
+
+    run_opcode_test(sim, result, Register.D0, 0x1DD, 2, [True, True, False, False, True])
+
+
+def test_ccr_carry():
+    """
+    Tests to see that the carry bit is set correctly
+
+    Example case used:
+        MOVE.L #-100,D0
+        NEG.L D0
+    """
+
+    sim = M68K()
+
+    sim.set_program_counter_value(0x1000)
+
+    sim.set_register(Register.D0, MemoryValue(OpSize.LONG, signed_int=-100))
+
+    neg = Neg([AssemblyParameter(EAMode.DRD, 0)], OpSize.LONG)
+
+    run_opcode_test(sim, neg, Register.D0, 0x1FF, 2, [True, False, False, False, True])
+
+
+def test_ccr_overflow():
+    """
+    Tests to see that the overflow bit is set correctly
+
+    Example case used:
+        MOVE.L #$80,D0
+        NEG.B D0
+    """
+
+    sim = M68K()
+
+    sim.set_program_counter_value(0x1000)
+
+    sim.set_register(Register.D0, MemoryValue(OpSize.LONG, unsigned_int=0x80))
+
+    neg = Neg([AssemblyParameter(EAMode.DRD, 0)], OpSize.BYTE)
+
+    run_opcode_test(sim, neg, Register.D0, 0x80, 2, [True, True, False, True, True])
+
+
+def test_ccr_zero():
+    """
+    Tests to see that the zero bit is set correctly
+
+    Example case used:
+        MOVE.L #0,D0
+        NEG.B  D0
+    """
+
+    sim = M68K()
+
+    sim.set_program_counter_value(0x1000)
+
+    sim.set_register(Register.D0, MemoryValue(OpSize.LONG, unsigned_int=0))
+
+    neg = Neg([AssemblyParameter(EAMode.DRD, 0)], OpSize.BYTE)
+
+    run_opcode_test(sim, neg, Register.D0, 0x0, 2, [False, False, True, False, False])
+
+
+def test_neg_assemble():
+    """
+    Check that assembly is the same as the input
+
+    Example case used:
+        NEG.W (A6)+
+    """
+
+    data = bytearray.fromhex('445E')
+
+    result = Neg.disassemble_instruction(data)
+
+    assm = result.assemble()
+
+    assert data == assm

--- a/tests/easier68k/core/opcodes/test_neg.py
+++ b/tests/easier68k/core/opcodes/test_neg.py
@@ -92,7 +92,7 @@ def test_ccr_carry():
 
     neg = Neg([AssemblyParameter(EAMode.DRD, 0)], OpSize.LONG)
 
-    run_opcode_test(sim, neg, Register.D0, 0x1FF, 2, [True, False, False, False, True])
+    run_opcode_test(sim, neg, Register.D0, 100, 2, [True, False, False, False, True])
 
 
 def test_ccr_overflow():

--- a/tests/run_doctest.py
+++ b/tests/run_doctest.py
@@ -24,6 +24,7 @@ test_modules = [
     'easier68k.core.opcodes.adda',
     'easier68k.core.opcodes.dc',
     'easier68k.core.opcodes.lea',
+    'easier68k.core.opcodes.neg',
     'easier68k.core.opcodes.simhalt',
     'easier68k.core.opcodes.trap',
     'easier68k.core.models.list_file',


### PR DESCRIPTION
Fixes #16 

Adds the Negate (NEG) Opcode. Subtracts the destination operand from 0 and stores the result in the destination location. NEG performs a 2's complement. All bits of the CCR are modified by a NEG operation.